### PR TITLE
endpoints create, put y delete de comments, totalmente funcional

### DIFF
--- a/src/modules/comments/comments.controller.ts
+++ b/src/modules/comments/comments.controller.ts
@@ -1,42 +1,62 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards, Req, Put } from '@nestjs/common';
 import { CommentsService } from './comments.service';
 import { CreateCommentDto } from './dto/create-comment.dto';
 import { UpdateCommentDto } from './dto/update-comment.dto';
-import { ApiBody, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
+import { JwtAuthGuard } from 'src/guards/jwt-auth.guard';
+import { AuthRequest } from '../auth/interfaces/auth-request.interface';
 
 @Controller('comments')
+@ApiBearerAuth()
 export class CommentsController {
   constructor(private readonly commentsService: CommentsService) {}
 
   @Post()
+  @UseGuards(JwtAuthGuard)
   @ApiOperation({summary: "Publish a comment"})
   @ApiResponse({status: 201, description: 'Comment created successfully'})
   @ApiResponse({ status: 400, description: 'Invalid request data' })
   @ApiResponse({ status: 500, description: 'Internal server error' })
   @ApiBody ({type: CreateCommentDto})
-  async createComment(
+  async createComment (
     @Param('postId') postId: string,
-    @Body() createCommentDto: CreateCommentDto) {
-    return this.commentsService.create(postId, createCommentDto);
+    @Body() createCommentDto: CreateCommentDto,
+    @Req() req: AuthRequest) {
+    return this.commentsService.create(postId, req.user.id, createCommentDto);
   }
 
-  @Get()
-  findAll() {
-    return this.commentsService.findAll();
-  }
-
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.commentsService.findOne(+id);
-  }
-
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updateCommentDto: UpdateCommentDto) {
-    return this.commentsService.update(+id, updateCommentDto);
+  @Put(':id') 
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Update a comment' })
+  @ApiParam({ name: 'id', description: 'ID of the comment to update' })
+  @ApiResponse({ status: 200, description: 'Comment updated successfully' })
+  @ApiResponse({ status: 400, description: 'Invalid request data' })
+  @ApiResponse({ status: 404, description: 'Comment not found' })
+  @ApiResponse({ status: 500, description: 'Internal server error' })
+  async updateComment(
+    @Param('id') id: string,
+    @Body() updateCommentDto: UpdateCommentDto,
+    @Req() req: AuthRequest
+  ) {
+    return this.commentsService.update(id, req.user.id, updateCommentDto);
   }
 
   @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.commentsService.remove(+id);
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Delete a comment' })
+  @ApiParam({ name: 'id', description: 'ID of the comment to delete' })
+  @ApiResponse({ status: 200, description: 'Comment deleted successfully' })
+  @ApiResponse({ status: 400, description: 'Invalid request data' })
+  @ApiResponse({ status: 404, description: 'Comment not found' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
+  @ApiResponse({ status: 500, description: 'Internal server error' })
+  async deleteComment(
+    @Param('id') id: string,
+    @Req() req: AuthRequest,
+  ) {
+    return this.commentsService.delete(id, req.user.id);
   }
 }
+
+  
+

--- a/src/modules/comments/comments.service.ts
+++ b/src/modules/comments/comments.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException} from '@nestjs/common';
+import { ForbiddenException, Injectable, NotFoundException} from '@nestjs/common';
 import { CreateCommentDto } from './dto/create-comment.dto';
 import { UpdateCommentDto } from './dto/update-comment.dto';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -6,6 +6,7 @@ import { Repository } from 'typeorm';
 import { User } from '../users/entities/user.entity';
 import { Post } from '../posts/entities/post.entity';
 import { Comment } from './entities/comment.entity';
+import { ResponseCommentDto } from './dto/response-comment.dto';
 
 @Injectable()
 
@@ -18,9 +19,8 @@ export class CommentsService {
   ) {}
 
  
-  async create(postId: string, createCommentDto: CreateCommentDto) {
-    const { userId, content } = createCommentDto;
-
+  async create(postId: string, userId: string, createCommentDto: CreateCommentDto) {
+   
     const user = await this.usersRepository.findOne({ where: { id: userId } });
     if (!user) {
       throw new NotFoundException('User not found');
@@ -31,43 +31,89 @@ export class CommentsService {
       throw new NotFoundException('Post not found');
     }
 
-    const newComment = new Comment();
-      newComment.content = content;
-      newComment.user = user;
-      newComment.post = post;
+    const comment = this.commentsRepository.create({
+      ...createCommentDto,
+      post,
+      user,
+    });
 
+    await this.commentsRepository.save(comment);
 
-      await this.commentsRepository.save(newComment);
-    // const newComment = this.commentsRepository.create({
-    //   content,
-    //   user,
-    //   post,
-    // })// as Comment;
-    // console.log(newComment);
+    const response: ResponseCommentDto = {
+      success: true,
+      message: 'Comment added successfully',
+      comment: {
+        id: comment.id,
+        content: comment.content,
+        ...(comment.mediaUrl && { mediaUrl: comment.mediaUrl }), 
+        createdAt: comment.createdAt.toISOString(),
+        postId: comment.post.id,
+        userId: comment.user.id,
+      },
+    };
+      return response;
+  }
+   
+  async update (
+    id:string, 
+    userId: string, 
+    updateCommentDto: UpdateCommentDto
+  ): Promise <ResponseCommentDto>
+   {
+    const comment = await this.commentsRepository.findOne({ 
+      where: { id }, 
+      relations: ['user', 'post'] 
+    });
 
-    // await this.commentsRepository.save(newComment);
+    if (!comment)
+      throw new NotFoundException('Comment not found');
+
+    if (comment.user.id !== userId) {
+      throw new ForbiddenException('You are not allowed to update this comment');
+    }
+
+    if (updateCommentDto.content) {
+      comment.content = updateCommentDto.content;
+    }
+    if (updateCommentDto.mediaUrl) {
+      comment.mediaUrl = updateCommentDto.mediaUrl;
+    }
+
+    const updatedComment = await this.commentsRepository.save(comment);
+    const response: ResponseCommentDto = {
+      success: true,
+      message: 'Comment updated successfully',
+      comment: {
+        id: updatedComment.id,
+        content: updatedComment.content,
+        ...(updatedComment.mediaUrl && { mediaUrl: updatedComment.mediaUrl }),
+        createdAt: updatedComment.createdAt.toISOString(),
+        postId: updatedComment.post.id,
+        userId: updatedComment.user.id,
+      },
+    };
+  
+    return response;
+  }
+
+  async delete(id: string, userId: string): Promise<{ message: string }> {
+    const comment = await this.commentsRepository.findOne({
+      where: { id },
+      relations: ['user', 'post'], 
+    });
+
+    if (!comment) {
+      throw new NotFoundException('Comment not found');
+    }
+    if (comment.user.id !== userId) {
+      throw new ForbiddenException('You are not allowed to delete this comment');
+    }
+    
+    await this.commentsRepository.remove(comment);
 
     return {
-      id: newComment.id,
-      postId: post.id,
-      userId: user.id,
-      content: newComment.content,
-      createdAt: newComment.createdAt,
+      message: 'Comment deleted successfully',
     };
-  } 
-  findAll() {
-    return `This action returns all comments`;
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} comment`;
-  }
-
-  update(id: number, updateCommentDto: UpdateCommentDto) {
-    return `This action updates a #${id} comment`;
-  }
-
-  remove(id: number) {
-    return `This action removes a #${id} comment`;
-  }
 }

--- a/src/modules/comments/dto/comment.dto.ts
+++ b/src/modules/comments/dto/comment.dto.ts
@@ -1,0 +1,22 @@
+import { IsString, IsOptional, IsUUID } from 'class-validator';
+
+export class CommentDto {
+  @IsUUID()
+  id: string;
+
+  @IsString()
+  content: string;
+
+  @IsOptional()
+  @IsString()
+  mediaUrl?: string;
+
+  @IsString()
+  createdAt: string;
+
+  @IsUUID()
+  postId: string;
+
+  @IsUUID()
+  userId: string;
+}

--- a/src/modules/comments/dto/create-comment.dto.ts
+++ b/src/modules/comments/dto/create-comment.dto.ts
@@ -1,18 +1,21 @@
-import { IsUUID, IsNotEmpty } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString, IsUrl } from 'class-validator';
 
 export class CreateCommentDto {
-  @ApiProperty({ description: 'Contenido del comentario', example: 'Este es un comentario de prueba' })
-  @IsNotEmpty({ message: 'El contenido no puede estar vacío' })
+  @ApiProperty({
+    description: 'Comment content',
+    example: 'Este es un comentario de prueba.',
+  })
+  @IsString()
   content: string;
 
-  @ApiProperty({ description: 'ID del usuario que realiza el comentario', example: '123e4567-e89b-12d3-a456-426614174000' })
-  @IsNotEmpty()
-  @IsUUID()
-  userId: string;
-
-  @ApiProperty({ description: 'ID del post al que pertenece el comentario', example: '987e6543-a21b-45c7-89d3-123456789abc' })
-  @IsNotEmpty()
-  @IsUUID()
-  postId: string;
+  @ApiProperty({
+    description: 'Optional media URL (image, video, gif, etc.)',
+    example: 'https://example.com/image.jpg',
+    required: false,
+    nullable: true,
+  })
+  @IsOptional()
+  @IsUrl()
+  mediaUrl?: string;
 }

--- a/src/modules/comments/dto/response-comment.dto.ts
+++ b/src/modules/comments/dto/response-comment.dto.ts
@@ -1,0 +1,13 @@
+import { IsString, IsOptional, IsUUID } from 'class-validator';
+import { CreateCommentDto } from './create-comment.dto';
+import { CommentDto } from './comment.dto';
+
+export class ResponseCommentDto {
+  @IsString()
+  success: boolean;
+
+  @IsString()
+  message: string;
+
+  comment: CommentDto
+}

--- a/src/modules/comments/dto/update-comment.dto.ts
+++ b/src/modules/comments/dto/update-comment.dto.ts
@@ -1,4 +1,21 @@
-import { PartialType } from '@nestjs/mapped-types';
+import { IsOptional, IsString, IsUrl } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { CreateCommentDto } from './create-comment.dto';
 
-export class UpdateCommentDto extends PartialType(CreateCommentDto) {}
+export class UpdateCommentDto {
+  @ApiPropertyOptional({
+    description: 'Optional new content for the comment',
+    example: 'Este es el comentario actualizado.'
+  })
+  @IsOptional()
+  @IsString()
+  content?: string;
+
+  @ApiPropertyOptional({
+    description: 'Optional new media URL for the comment',
+    example: 'https://example.com/new-image.jpg'
+  })
+  @IsOptional()
+  @IsUrl()
+  mediaUrl?: string;
+}

--- a/src/modules/comments/entities/comment.entity.ts
+++ b/src/modules/comments/entities/comment.entity.ts
@@ -11,6 +11,9 @@ export class Comment {
   @Column({ type: "text" })
   content: string;
 
+  @Column({ type: "text", nullable: true })
+  mediaUrl?: string;
+  
   @CreateDateColumn()
   createdAt: Date;
 


### PR DESCRIPTION
*Modifique el método create para que reciba por Req el userId desde el token, por Param el id del post y por body el contenido y media url
*No se muestra null en la respuesta en caso de no poner mediaurl
*Dto de respuesta para manejar correctamente las promesas en el servicio
*se actualiza y se elimina correctamente el comentario
**Proximos pasos**
Desde el módulo posts obtener los comentarios de una publicación, crear un método para obtener todos los comentarios de un usuario
Desarrollar el módulo de reactions, deberán ser aplicables a comentarios y publicaciones